### PR TITLE
feat(oms): add order persistence and safety handling for pending orders

### DIFF
--- a/changes/feature-oms-scaffold.md
+++ b/changes/feature-oms-scaffold.md
@@ -1,0 +1,16 @@
+# changes/feature-oms-scaffold.md
+
+Scope
+- Implement initial Order Management System (OMS) scaffolding.
+- Provide order model, lifecycle constants, and basic validation tests.
+
+What will be added
+- `trader/models/order.py` (order model dataclass)
+- `tests/test_orders.py` with basic lifecycle and validation tests
+- `CHANGELOG.md` entry (unreleased) updated when implementation completes
+
+Status
+- in-progress
+
+Notes
+- This is an incremental change: start with tests and minimal model, then expand to validators and persistence in later steps.

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,0 +1,51 @@
+"""Tests for basic order model and lifecycle."""
+
+from decimal import Decimal
+import pytest
+from trader.models.order import Order, OrderSide, OrderType, OrderStatus
+
+
+def test_order_creation():
+    o = Order(symbol="AAPL", side=OrderSide.BUY, qty=Decimal("10"), order_type=OrderType.MARKET)
+    assert o.symbol == "AAPL"
+    assert o.side == OrderSide.BUY
+    assert o.qty == Decimal("10")
+    assert o.order_type == OrderType.MARKET
+    assert o.status == OrderStatus.NEW
+
+
+def test_order_lifecycle():
+    o = Order(symbol="AAPL", side=OrderSide.SELL, qty=Decimal("5"), order_type=OrderType.LIMIT, limit_price=Decimal("150"))
+    assert o.status == OrderStatus.NEW
+    o.mark_submitted("ext-123")
+    assert o.status == OrderStatus.SUBMITTED
+    assert o.external_id == "ext-123"
+    o.mark_filled()
+    assert o.status == OrderStatus.FILLED
+
+
+def test_order_validation():
+    o = Order(symbol="AAPL", side=OrderSide.BUY, qty=Decimal("1"), order_type=OrderType.MARKET)
+    o.validate()
+
+    # invalid quantity
+    with pytest.raises(ValueError):
+        Order(symbol="AAPL", side=OrderSide.BUY, qty=Decimal("0"), order_type=OrderType.MARKET).validate()
+
+    # limit order requires limit_price
+    with pytest.raises(ValueError):
+        Order(symbol="AAPL", side=OrderSide.SELL, qty=Decimal("1"), order_type=OrderType.LIMIT).validate()
+
+
+def test_order_persistence(tmp_path):
+    from trader.oms.store import save_orders, load_orders
+
+    o1 = Order(symbol="AAPL", side=OrderSide.BUY, qty=Decimal("2"), order_type=OrderType.MARKET)
+    o2 = Order(symbol="TSLA", side=OrderSide.SELL, qty=Decimal("3"), order_type=OrderType.LIMIT, limit_price=Decimal("400"))
+
+    save_orders([o1, o2], tmp_path)
+    loaded = load_orders(tmp_path)
+
+    assert len(loaded) == 2
+    assert loaded[0].symbol == "AAPL"
+    assert loaded[1].symbol == "TSLA"

--- a/tests/test_safety_pending_orders.py
+++ b/tests/test_safety_pending_orders.py
@@ -1,0 +1,70 @@
+"""Tests for safety checks that consider pending orders saved to orders.yaml."""
+from decimal import Decimal
+from pathlib import Path
+
+from trader.core.safety import SafetyCheck, SafetyLimits
+from trader.data.ledger import TradeLedger
+from trader.oms.store import save_orders
+from trader.models.order import Order as LocalOrder, OrderSide, OrderType, OrderStatus
+
+
+class MockBroker:
+    def __init__(self, position_qty=Decimal("0"), position_value=Decimal("0"), buying_power=Decimal("10000")):
+        self._position_qty = position_qty
+        self._position_value = position_value
+        self._account = type("A", (), {"cash": Decimal("10000"), "buying_power": buying_power, "equity": Decimal("0"), "currency": "USD"})
+
+    def get_position(self, symbol: str):
+        if self._position_qty == 0:
+            return None
+        return type("P", (), {"qty": self._position_qty, "market_value": self._position_value})
+
+    def get_account(self):
+        return self._account
+
+    def get_quote(self, symbol: str):
+        return type("Q", (), {"bid": Decimal("99"), "ask": Decimal("101"), "last": Decimal("100"), "volume": 1000})
+
+
+class DummyLedger(TradeLedger):
+    def __init__(self):
+        # do not call super
+        pass
+
+    def get_total_today_pnl(self):
+        return Decimal("0")
+
+    def get_trade_count_today(self):
+        return 0
+
+
+def test_pending_buys_reduce_buying_power(tmp_path: Path):
+    # Create a pending buy order for 50 shares @ limit 100 (value 5000)
+    o = LocalOrder(symbol="AAPL", side=OrderSide.BUY, qty=Decimal("50"), order_type=OrderType.LIMIT, limit_price=Decimal("100"))
+    save_orders([o], tmp_path)
+
+    broker = MockBroker(position_qty=Decimal("0"), position_value=Decimal("0"), buying_power=Decimal("6000"))
+    ledger = DummyLedger()
+    limits = SafetyLimits(max_position_value=Decimal("100000"))
+    checker = SafetyCheck(broker, ledger, limits=limits, orders_dir=tmp_path)
+
+    # Attempt to place a new buy for 20 shares @ 100 (value 2000). Available buying power = 6000 - 5000 = 1000 -> should be blocked
+    allowed, reason = checker.check_order("AAPL", 20, Decimal("100"), is_buy=True)
+    assert allowed is False
+    assert "Insufficient buying power" in reason
+
+
+def test_pending_buys_count_toward_position_size(tmp_path: Path):
+    # Create a pending buy for 60 shares
+    o = LocalOrder(symbol="AAPL", side=OrderSide.BUY, qty=Decimal("60"), order_type=OrderType.LIMIT, limit_price=Decimal("100"))
+    save_orders([o], tmp_path)
+
+    broker = MockBroker(position_qty=Decimal("10"), position_value=Decimal("1000"), buying_power=Decimal("20000"))
+    ledger = DummyLedger()
+    limits = SafetyLimits(max_position_value=Decimal("100000"))
+    checker = SafetyCheck(broker, ledger, limits=limits, orders_dir=tmp_path)
+
+    # Max position size default is 100. Existing 10 + pending 60 + new 40 = 110 > 100 -> should be blocked
+    allowed, reason = checker.check_order("AAPL", 40, Decimal("100"), is_buy=True)
+    assert allowed is False
+    assert "exceeds position size limit" in reason

--- a/trader/models/order.py
+++ b/trader/models/order.py
@@ -1,0 +1,91 @@
+"""Order model for OMS scaffold."""
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+from pathlib import Path
+from decimal import InvalidOperation
+from typing import Any
+
+
+class OrderSide(Enum):
+    BUY = "buy"
+    SELL = "sell"
+
+
+class OrderType(Enum):
+    MARKET = "market"
+    LIMIT = "limit"
+
+
+class OrderStatus(Enum):
+    NEW = "new"
+    SUBMITTED = "submitted"
+    FILLED = "filled"
+    CANCELED = "canceled"
+
+
+@dataclass
+class Order:
+    symbol: str
+    side: OrderSide
+    qty: Decimal
+    order_type: OrderType
+    limit_price: Optional[Decimal] = None
+    id: str = field(default_factory=lambda: "")
+    external_id: Optional[str] = None
+    status: OrderStatus = OrderStatus.NEW
+
+    def validate(self) -> None:
+        """Validate order fields.
+
+        Raises:
+            ValueError: if validation fails.
+        """
+        if self.qty <= 0:
+            raise ValueError("Quantity must be positive")
+
+        if self.order_type == OrderType.LIMIT:
+            if self.limit_price is None:
+                raise ValueError("Limit orders require a limit_price")
+            if self.limit_price <= 0:
+                raise ValueError("Limit price must be positive")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "symbol": self.symbol,
+            "side": self.side.value,
+            "qty": str(self.qty),
+            "order_type": self.order_type.value,
+            "limit_price": str(self.limit_price) if self.limit_price is not None else None,
+            "external_id": self.external_id,
+            "status": self.status.value,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Order":
+        lp = None
+        if data.get("limit_price") is not None:
+            lp = Decimal(str(data["limit_price"]))
+
+        return cls(
+            id=data.get("id", ""),
+            symbol=data["symbol"],
+            side=OrderSide(data["side"]),
+            qty=Decimal(str(data["qty"])),
+            order_type=OrderType(data["order_type"]),
+            limit_price=lp,
+            external_id=data.get("external_id"),
+            status=OrderStatus(data.get("status", OrderStatus.NEW.value)),
+        )
+
+    def mark_submitted(self, external_id: str) -> None:
+        self.external_id = external_id
+        self.status = OrderStatus.SUBMITTED
+
+    def mark_filled(self) -> None:
+        self.status = OrderStatus.FILLED
+
+    def mark_canceled(self) -> None:
+        self.status = OrderStatus.CANCELED

--- a/trader/oms/store.py
+++ b/trader/oms/store.py
@@ -1,0 +1,96 @@
+"""Simple order persistence (YAML) for the OMS scaffold."""
+from pathlib import Path
+from typing import Optional
+import yaml
+
+from trader.models.order import Order
+
+
+def get_orders_file(config_dir: Optional[Path] = None) -> Path:
+    if config_dir is None:
+        config_dir = Path(__file__).parent.parent.parent / "config"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    return config_dir / "orders.yaml"
+
+
+def save_orders(orders: list[Order], config_dir: Optional[Path] = None) -> None:
+    path = get_orders_file(config_dir)
+    data = {"orders": [o.to_dict() for o in orders]}
+    with open(path, "w") as f:
+        yaml.dump(data, f, default_flow_style=False, sort_keys=False)
+
+
+def load_orders(config_dir: Optional[Path] = None) -> list[Order]:
+    path = get_orders_file(config_dir)
+    if not path.exists():
+        return []
+    with open(path) as f:
+        data = yaml.safe_load(f) or {}
+    items = data.get("orders", [])
+    return [Order.from_dict(i) for i in items]
+
+
+def _to_local_order(order_obj: object) -> Order:
+    """Convert a broker.Order-like object or local Order dict to local `Order` model."""
+    # Import local enums
+    from trader.models.order import Order as LocalOrder, OrderSide as LocalSide, OrderType as LocalType, OrderStatus as LocalStatus
+
+    # Extract fields with fallbacks
+    oid = getattr(order_obj, "id", getattr(order_obj, "order_id", ""))
+    symbol = getattr(order_obj, "symbol")
+    qty = getattr(order_obj, "qty")
+    # Side may be enum or string
+    side_raw = getattr(order_obj, "side")
+    try:
+        side = LocalSide(side_raw.value) if hasattr(side_raw, "value") else LocalSide(side_raw)
+    except Exception:
+        side = LocalSide.BUY
+
+    ot_raw = getattr(order_obj, "order_type", getattr(order_obj, "orderType", None))
+    try:
+        order_type = LocalType(ot_raw.value) if hasattr(ot_raw, "value") else LocalType(ot_raw)
+    except Exception:
+        order_type = LocalType.MARKET
+
+    limit_price = getattr(order_obj, "limit_price", None)
+    external_id = getattr(order_obj, "external_id", None)
+
+    status_raw = getattr(order_obj, "status", None)
+    try:
+        status = LocalStatus(status_raw.value) if hasattr(status_raw, "value") else LocalStatus(status_raw)
+    except Exception:
+        status = LocalStatus.NEW
+
+    return LocalOrder(
+        id=oid or "",
+        symbol=symbol,
+        side=side,
+        qty=qty,
+        order_type=order_type,
+        limit_price=limit_price,
+        external_id=external_id,
+        status=status,
+    )
+
+
+def save_order(order_obj: object, config_dir: Optional[Path] = None) -> None:
+    """Save or update a single order to the orders file.
+
+    Accepts either a local `Order` instance or a broker-like Order object.
+    """
+    orders = load_orders(config_dir)
+
+    local = order_obj if isinstance(order_obj, Order) else _to_local_order(order_obj)
+
+    # Replace existing by id if found
+    replaced = False
+    for i, o in enumerate(orders):
+        if o.id and o.id == local.id:
+            orders[i] = local
+            replaced = True
+            break
+
+    if not replaced:
+        orders.append(local)
+
+    save_orders(orders, config_dir)


### PR DESCRIPTION
- Add OMS YAML persistence and save_order helper\n- Add Order model validation and serialization\n- Include pending orders in SafetyCheck (reserved qty/value)\n- Persist orders from CLI after placement\n- CLI: show pending local orders and reserved buying power\n- Add tests for orders, OMS store, and safety/pending orders\n