### PR TITLE
Add central audit log for CLI and MCP (MCP Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+- **Central audit log (MCP Phase 3)** — `trader/audit.py` appends structured JSONL to `logs/audit.log` for sensitive actions from both CLI and MCP. Logged actions: `place_order`, `place_order_blocked`, `cancel_order`, `create_strategy`, `remove_strategy`, `run_backtest`, `stop_engine`. Each record includes timestamp (UTC), source (`cli` or `mcp`), action, details, and optional error. Audit source is set via context (CLI sets at startup; MCP sets per tool call).
+
 ## [0.5.0] - 2026-02-11
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ AutoTrader enforces multiple layers of protection:
 * Position size limits
 * Daily loss limits
 * Kill switch available
-* Immutable audit logs
+* Immutable audit logs — `logs/audit.log` (JSONL) records place_order, cancel_order, create_strategy, remove_strategy, run_backtest, stop_engine from both CLI and MCP, with source and timestamp
 
 **Never deploy to production without extensive paper testing.**
 

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,66 @@
+"""Tests for the central audit log (Phase 3)."""
+
+from pathlib import Path
+
+from trader.audit import get_audit_source, log_action, set_audit_source
+
+
+def test_set_and_get_audit_source() -> None:
+    set_audit_source("cli")
+    assert get_audit_source() == "cli"
+    set_audit_source("mcp")
+    assert get_audit_source() == "mcp"
+
+
+def test_log_action_no_write_when_log_dir_none() -> None:
+    """When log_dir is None, log_action does not write or raise."""
+    log_action("test_action", {"key": "value"}, log_dir=None)
+    # No exception; no file created
+
+
+def test_log_action_writes_jsonl(tmp_path: Path) -> None:
+    """log_action appends one JSON line to audit.log."""
+    set_audit_source("cli")
+    log_action("place_order", {"symbol": "AAPL", "qty": 10}, log_dir=tmp_path)
+    log_file = tmp_path / "audit.log"
+    assert log_file.exists()
+    lines = log_file.read_text().strip().split("\n")
+    assert len(lines) == 1
+    record = __import__("json").loads(lines[0])
+    assert record["source"] == "cli"
+    assert record["action"] == "place_order"
+    assert record["details"] == {"symbol": "AAPL", "qty": 10}
+    assert "ts" in record
+    assert "error" not in record
+
+
+def test_log_action_with_error(tmp_path: Path) -> None:
+    """log_action includes error field when provided."""
+    set_audit_source("mcp")
+    log_action(
+        "place_order",
+        {"symbol": "TSLA"},
+        error="Order placement failed",
+        log_dir=tmp_path,
+    )
+    record = __import__("json").loads((tmp_path / "audit.log").read_text().strip())
+    assert record["error"] == "Order placement failed"
+    assert record["source"] == "mcp"
+
+
+def test_log_action_appends(tmp_path: Path) -> None:
+    """Multiple log_action calls append to the same file."""
+    set_audit_source("cli")
+    log_action("action_a", {"x": 1}, log_dir=tmp_path)
+    log_action("action_b", {"x": 2}, log_dir=tmp_path)
+    lines = (tmp_path / "audit.log").read_text().strip().split("\n")
+    assert len(lines) == 2
+    assert __import__("json").loads(lines[0])["action"] == "action_a"
+    assert __import__("json").loads(lines[1])["action"] == "action_b"
+
+
+def test_log_action_creates_log_dir(tmp_path: Path) -> None:
+    """log_action creates parent directory if needed."""
+    log_dir = tmp_path / "nested" / "logs"
+    log_action("test", {}, log_dir=log_dir)
+    assert (log_dir / "audit.log").exists()

--- a/trader/app/backtests.py
+++ b/trader/app/backtests.py
@@ -7,6 +7,7 @@ from decimal import Decimal
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
+from trader.audit import log_action as audit_log
 from trader.errors import NotFoundError, ValidationError
 from trader.schemas.backtests import BacktestRequest, BacktestResponse, BacktestSummary
 from trader.utils.config import Config
@@ -119,6 +120,17 @@ def run_backtest(config: Config, request: BacktestRequest) -> BacktestResponse:
     if request.save:
         save_backtest(result)
 
+    audit_log(
+        "run_backtest",
+        {
+            "strategy_type": request.strategy_type,
+            "symbol": request.symbol,
+            "start": request.start,
+            "end": request.end,
+            "backtest_id": result.id,
+        },
+        log_dir=config.log_dir,
+    )
     return BacktestResponse.from_domain(result)
 
 

--- a/trader/app/engine.py
+++ b/trader/app/engine.py
@@ -135,6 +135,14 @@ def stop_engine(force: bool = False) -> dict[str, str]:
 
     try:
         os.kill(pid, sig)
+        from trader.audit import log_action as audit_log
+        from trader.utils.config import load_config
+
+        audit_log(
+            "stop_engine",
+            {"pid": pid, "force": force},
+            log_dir=load_config().log_dir,
+        )
         if force:
             try:
                 lock_path.unlink()

--- a/trader/app/strategies.py
+++ b/trader/app/strategies.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+from trader.audit import log_action as audit_log
 from trader.errors import NotFoundError, ValidationError
 from trader.schemas.strategies import (
     StrategyCreate,
@@ -197,6 +198,11 @@ def create_strategy(config: Config, request: StrategyCreate) -> StrategyResponse
         )
 
     _save_strategy(strat)
+    audit_log(
+        "create_strategy",
+        {"strategy_type": request.strategy_type, "symbol": strat.symbol, "strategy_id": strat.id},
+        log_dir=config.log_dir,
+    )
     return StrategyResponse.from_domain(strat)
 
 
@@ -217,6 +223,9 @@ def remove_strategy(strategy_id: str) -> dict[str, str]:
             message=f"Strategy {strategy_id} not found",
             code="STRATEGY_NOT_FOUND",
         )
+    from trader.utils.config import load_config
+
+    audit_log("remove_strategy", {"strategy_id": strategy_id}, log_dir=load_config().log_dir)
     return {"status": "removed", "strategy_id": strategy_id}
 
 

--- a/trader/audit.py
+++ b/trader/audit.py
@@ -1,0 +1,61 @@
+"""Central audit log for CLI and MCP actions.
+
+Phase 3 (MCP roadmap): log sensitive operations from both interfaces
+so we have an immutable trail for compliance and debugging.
+"""
+
+from __future__ import annotations
+
+import json
+from contextvars import ContextVar
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+_audit_source: ContextVar[str] = ContextVar("audit_source", default="cli")
+
+
+def set_audit_source(source: str) -> None:
+    """Set the current audit source (e.g. 'cli' or 'mcp') for this context."""
+    _audit_source.set(source)
+
+
+def get_audit_source() -> str:
+    """Return the current audit source."""
+    return _audit_source.get()
+
+
+def log_action(
+    action: str,
+    details: dict[str, Any],
+    *,
+    error: str | None = None,
+    log_dir: Path | None = None,
+) -> None:
+    """Append one audit record to the audit log.
+
+    Args:
+        action: Action name (e.g. 'place_order', 'create_strategy', 'stop_engine').
+        details: Structured details (symbol, qty, order_id, etc.). Keep small; no secrets.
+        error: If the action failed, a short error message.
+        log_dir: Directory for audit.log. If None, no write (caller should pass config.log_dir).
+    """
+    if log_dir is None:
+        return
+    log_dir = Path(log_dir)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "audit.log"
+    record = {
+        "ts": datetime.now(tz=datetime.UTC).isoformat(),
+        "source": get_audit_source(),
+        "action": action,
+        "details": details,
+    }
+    if error is not None:
+        record["error"] = error
+    line = json.dumps(record, default=str) + "\n"
+    try:
+        with open(log_file, "a") as f:
+            f.write(line)
+    except OSError:
+        pass  # Don't fail the request if audit write fails

--- a/trader/cli/main.py
+++ b/trader/cli/main.py
@@ -18,6 +18,7 @@ from rich.console import Console
 from rich.table import Table
 
 from trader import __version__
+from trader.audit import set_audit_source
 from trader.errors import AppError
 from trader.utils.config import Environment, load_config
 from trader.utils.logging import setup_logging
@@ -77,6 +78,7 @@ def cli(ctx: click.Context, prod: bool, as_json: bool) -> None:
             f.write(f"{datetime.now().isoformat()} | CLI entry point called\n")
 
         ctx.ensure_object(dict)
+        set_audit_source("cli")
         config = load_config(prod=prod)
         ctx.obj["config"] = config
         ctx.obj["json"] = as_json

--- a/trader/mcp/server.py
+++ b/trader/mcp/server.py
@@ -596,6 +596,20 @@ def get_safety_status() -> str:
 # =============================================================================
 
 
+def _with_mcp_audit(fn: Any) -> Any:
+    """Wrap a tool so audit source is set to 'mcp' for the duration of the call."""
+    import functools
+
+    @functools.wraps(fn)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        from trader.audit import set_audit_source
+
+        set_audit_source("mcp")
+        return fn(*args, **kwargs)
+
+    return wrapper
+
+
 _ALL_TOOLS = [
     # Engine
     get_status,
@@ -640,7 +654,7 @@ _ALL_TOOLS = [
 def register_tools(server: FastMCP) -> None:
     """Register all MCP tools on the provided server."""
     for tool_fn in _ALL_TOOLS:
-        server.tool()(tool_fn)  # type: ignore[arg-type]
+        server.tool()(_with_mcp_audit(tool_fn))  # type: ignore[arg-type]
 
 
 # =============================================================================


### PR DESCRIPTION
- Add trader/audit.py: context-based source (cli|mcp), JSONL append to logs/audit.log
- Log place_order, place_order_blocked, cancel_order, create_strategy, remove_strategy, run_backtest, stop_engine from app layer
- Set audit source in CLI (cli() startup) and MCP (wrap all tools with _with_mcp_audit)
- Add tests/test_audit.py (6 tests)
- Update README Safety section and CHANGELOG [Unreleased]