### PR TITLE
feat: add notification system (Discord + webhook)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- **Notification system (Phase 3 Automation)** — Discord and generic webhook channels for alerts. New module `trader/notifications/` (NotificationManager, DiscordChannel, WebhookChannel, formatters). CLI: `trader notify test` and `trader notify send "message"`. Config via env (`DISCORD_WEBHOOK_URL`, `CUSTOM_WEBHOOK_URL`, `NOTIFICATIONS_ENABLED`) and optional `config/notifications.yaml` (see `config/notifications.yaml.example`). App layer: `trader/app/notifications.py` for use by engine or MCP later.
 - **Central audit log (MCP Phase 3)** — `trader/audit.py` appends structured JSONL to `logs/audit.log` for sensitive actions from both CLI and MCP. Logged actions: `place_order`, `place_order_blocked`, `cancel_order`, `create_strategy`, `remove_strategy`, `run_backtest`, `stop_engine`. Each record includes timestamp (UTC), source (`cli` or `mcp`), action, details, and optional error. Audit source is set via context (CLI sets at startup; MCP sets per tool call).
 - **MCP rate limits and timeouts (Phase 3)** — Long-running MCP tools (`run_backtest`, `run_optimization`) are now subject to configurable rate limits and per-call timeouts. New module `trader/mcp/limits.py`; env vars: `MCP_BACKTEST_TIMEOUT_SECONDS` (default 300), `MCP_OPTIMIZATION_TIMEOUT_SECONDS` (default 600), `MCP_RATE_LIMIT_LONG_RUNNING_PER_MINUTE` (default 10). New error types: `RateLimitError`, `TaskTimeoutError` in `trader/errors.py`. See README Configuration for details.
+
+### Fixed
+- **Audit log** — Use `timezone.utc` instead of `datetime.UTC` for compatibility in all Python 3.11+ environments.
 
 ## [0.5.0] - 2026-02-11
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Use the same Claude config as in the README: set `command` to the **full path** 
 - **trader/mcp/** — MCP server (agent-friendly, JSON)
 - **trader/schemas/** — Pydantic models (contracts)
 - **trader/errors.py** — Shared error hierarchy
-- **trader/core/**, **trader/backtest/**, **trader/strategies/**, **trader/api/**, **trader/data/**, **trader/indicators/**, **trader/oms/**, **trader/utils/** — Domain and infra
+- **trader/core/**, **trader/backtest/**, **trader/strategies/**, **trader/api/**, **trader/data/**, **trader/indicators/**, **trader/notifications/**, **trader/oms/**, **trader/utils/** — Domain and infra
 
 **Dual-interface architecture**: CLI and MCP are thin adapters; both call `trader/app` and use `trader/schemas`. One core, two adapters — no logic duplication.
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ AutoTrader is a command-line trading platform for **automated stock trading**. I
 * ✅ Portfolio tracking & trade ledger
 * ✅ Safety & risk controls
 * ✅ **Backtesting** with historical data
+* ✅ **Notifications** (Discord webhook, generic webhook) for alerts
 
 **Tools**: 28 MCP tools (engine, portfolio, orders, strategies, backtests, analysis, indicators, optimization, safety).
 
@@ -120,6 +121,18 @@ When using the MCP server, you can tune rate limits and timeouts for long-runnin
 | `MCP_OPTIMIZATION_TIMEOUT_SECONDS` | 600 | Max wall-clock time (seconds) for a single optimization run; 0 = no limit. |
 | `MCP_RATE_LIMIT_LONG_RUNNING_PER_MINUTE` | 10 | Max number of long-running tool calls (backtest + optimization combined) per 60-second window; 0 = no limit. |
 
+### Notifications (optional)
+
+Alerts can be sent to Discord or a custom webhook (e.g. for trade events or manual messages):
+
+| Variable | Description |
+|----------|-------------|
+| `DISCORD_WEBHOOK_URL` | Discord webhook URL (primary channel). |
+| `CUSTOM_WEBHOOK_URL` | Generic HTTP webhook URL (POST JSON with `message`). |
+| `NOTIFICATIONS_ENABLED` | Set to `false` or `0` to disable all notifications. |
+
+Optional YAML: copy `config/notifications.yaml.example` to `config/notifications.yaml` to configure events and channels. CLI: `trader notify test` (test delivery), `trader notify send "message"` (send manual message).
+
 ---
 
 ## ▶️ Usage
@@ -167,6 +180,18 @@ trader analyze
 
 # Filter by symbol and time window
 trader analyze --symbol AAPL --days 7
+```
+
+### Notifications
+
+```bash
+# Test notification delivery (requires DISCORD_WEBHOOK_URL or config)
+trader notify test
+trader notify test --channel discord
+
+# Send a manual message
+trader notify send "Trading paused for maintenance"
+trader notify send "AAPL target hit" --channel discord
 ```
 
 ---

--- a/config/notifications.yaml.example
+++ b/config/notifications.yaml.example
@@ -1,0 +1,21 @@
+# Copy to notifications.yaml and set env vars (e.g. DISCORD_WEBHOOK_URL).
+# Notifications are optional; env vars alone work: DISCORD_WEBHOOK_URL, CUSTOM_WEBHOOK_URL.
+
+notifications:
+  enabled: true
+
+  events:
+    trade_opened: true
+    trade_closed: true
+    strategy_started: true
+    strategy_stopped: true
+    error: true
+    daily_summary: true
+
+  channels:
+    discord:
+      enabled: true
+      webhook_url: ${DISCORD_WEBHOOK_URL}
+    webhook:
+      enabled: false
+      url: https://example.com/webhook

--- a/tests/notifications/__init__.py
+++ b/tests/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for notification system."""

--- a/tests/notifications/test_app_notifications.py
+++ b/tests/notifications/test_app_notifications.py
@@ -1,0 +1,40 @@
+"""Tests for app notification services."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from trader.app.notifications import (
+    get_notification_manager,
+    send_notification,
+    send_test_notification,
+)
+
+_ENV_KEYS_TO_DROP = ("DISCORD_WEBHOOK_URL", "CUSTOM_WEBHOOK_URL", "NOTIFICATIONS_ENABLED")
+
+
+def test_get_notification_manager_no_config() -> None:
+    """Manager from empty config dir has no channels if no env."""
+    with patch.dict(os.environ, {}, clear=False):
+        env_clean = {k: v for k, v in os.environ.items() if k not in _ENV_KEYS_TO_DROP}
+        with patch.dict(os.environ, env_clean, clear=False):
+            manager = get_notification_manager(config_dir=Path("/nonexistent"))
+    assert not manager.enabled
+
+
+def test_send_test_notification_no_channels_returns_false() -> None:
+    """send_test_notification returns False when no channels."""
+    with patch.dict(os.environ, {}, clear=False):
+        env_clean = {k: v for k, v in os.environ.items() if k not in _ENV_KEYS_TO_DROP}
+        with patch.dict(os.environ, env_clean, clear=False):
+            ok = send_test_notification(config_dir=Path("/nonexistent"))
+    assert ok is False
+
+
+def test_send_notification_no_channels_no_op() -> None:
+    """send_notification does nothing when no channels configured."""
+    with patch.dict(os.environ, {}, clear=False):
+        env_clean = {k: v for k, v in os.environ.items() if k not in _ENV_KEYS_TO_DROP}
+        with patch.dict(os.environ, env_clean, clear=False):
+            send_notification("hello", config_dir=Path("/nonexistent"))
+    # No exception

--- a/tests/notifications/test_discord.py
+++ b/tests/notifications/test_discord.py
@@ -1,0 +1,65 @@
+"""Tests for Discord notification channel."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from trader.notifications.channels.discord import DiscordChannel
+from trader.notifications.formatters import TradeNotification
+
+
+def test_discord_channel_requires_url() -> None:
+    """DiscordChannel raises if webhook URL is empty."""
+    with pytest.raises(ValueError, match="webhook URL"):
+        DiscordChannel("")
+    with pytest.raises(ValueError, match="webhook URL"):
+        DiscordChannel("   ")
+
+
+def test_discord_channel_name() -> None:
+    """Discord channel name is 'discord'."""
+    with patch.object(requests, "post") as mock_post:
+        mock_post.return_value = MagicMock(status_code=204)
+        ch = DiscordChannel("https://discord.com/api/webhooks/123/abc")
+    assert ch.name == "discord"
+
+
+def test_discord_send_posts_json() -> None:
+    """Discord send POSTs content to webhook URL."""
+    with patch.object(requests, "post") as mock_post:
+        mock_post.return_value = MagicMock(status_code=204)
+        ch = DiscordChannel("https://discord.com/api/webhooks/123/abc")
+        ch.send("Hello world")
+    mock_post.assert_called_once()
+    call_kw = mock_post.call_args[1]
+    assert call_kw["json"]["content"] == "Hello world"
+    assert "application/json" in str(call_kw["headers"])
+
+
+def test_discord_send_raises_on_http_error() -> None:
+    """Discord send raises on non-2xx response."""
+    with patch.object(requests, "post") as mock_post:
+        mock_post.return_value = MagicMock(status_code=400)
+        mock_post.return_value.raise_for_status.side_effect = requests.HTTPError("400")
+        ch = DiscordChannel("https://discord.com/api/webhooks/123/abc")
+        with pytest.raises(requests.HTTPError):
+            ch.send("fail")
+
+
+def test_discord_format_trade() -> None:
+    """Discord format_trade produces markdown with symbol and strategy."""
+    ch = DiscordChannel("https://discord.com/api/webhooks/1/2")
+    trade = TradeNotification(
+        symbol="AAPL",
+        side="buy",
+        quantity=10,
+        price=150.0,
+        strategy_name="trailing-stop",
+        timestamp=datetime(2024, 1, 15, 10, 0, 0),
+    )
+    msg = ch.format_trade(trade)
+    assert "AAPL" in msg
+    assert "trailing-stop" in msg
+    assert "150" in msg

--- a/tests/notifications/test_formatters.py
+++ b/tests/notifications/test_formatters.py
@@ -1,0 +1,54 @@
+"""Tests for notification formatters."""
+
+from datetime import datetime
+
+from trader.notifications.formatters import (
+    TradeNotification,
+    format_error_plain,
+    format_trade_plain,
+)
+
+
+def test_format_trade_plain_opened() -> None:
+    """Trade opened message includes symbol, side, qty, price, strategy."""
+    trade = TradeNotification(
+        symbol="AAPL",
+        side="buy",
+        quantity=10,
+        price=150.25,
+        strategy_name="trailing-stop",
+        timestamp=datetime(2024, 12, 1, 10, 30, 0),
+        event="trade_opened",
+    )
+    msg = format_trade_plain(trade)
+    assert "AAPL" in msg
+    assert "Opened" in msg
+    assert "BUY" in msg
+    assert "10" in msg
+    assert "150.25" in msg
+    assert "trailing-stop" in msg
+    assert "2024-12-01" in msg
+
+
+def test_format_trade_plain_closed() -> None:
+    """Trade closed uses Closed and sell side."""
+    trade = TradeNotification(
+        symbol="GOOGL",
+        side="sell",
+        quantity=5,
+        price=142.50,
+        strategy_name="bracket",
+        event="trade_closed",
+    )
+    msg = format_trade_plain(trade)
+    assert "Closed" in msg
+    assert "GOOGL" in msg
+    assert "SELL" in msg
+
+
+def test_format_error_plain() -> None:
+    """Error formatter includes exception type and message."""
+    msg = format_error_plain(ValueError("invalid symbol"))
+    assert "Error" in msg
+    assert "ValueError" in msg
+    assert "invalid symbol" in msg

--- a/tests/notifications/test_manager.py
+++ b/tests/notifications/test_manager.py
@@ -1,0 +1,76 @@
+"""Tests for NotificationManager."""
+
+import os
+from unittest.mock import patch
+
+from trader.notifications.formatters import TradeNotification
+from trader.notifications.manager import NotificationManager, _resolve_url
+
+
+def test_resolve_url_plain() -> None:
+    """Plain URL is returned as-is."""
+    assert _resolve_url("https://discord.com/api/webhooks/123") == "https://discord.com/api/webhooks/123"
+
+
+def test_resolve_url_env() -> None:
+    """${VAR} is resolved from environment."""
+    with patch.dict(os.environ, {"MY_WEBHOOK": "https://example.com/hook"}, clear=False):
+        assert _resolve_url("${MY_WEBHOOK}") == "https://example.com/hook"
+
+
+def test_manager_empty_config_no_channels() -> None:
+    """With no env and empty config, manager has no channels."""
+    with patch.dict(os.environ, {}, clear=False):
+        drop = ("DISCORD_", "CUSTOM_WEBHOOK", "NOTIFICATIONS_")
+        env = {k: v for k, v in os.environ.items() if not k.startswith(drop)}
+        with patch.dict(os.environ, env, clear=False):
+            manager = NotificationManager({})
+    assert manager.channel_names == []
+    assert manager.enabled is False
+
+
+def test_manager_disabled_by_env() -> None:
+    """NOTIFICATIONS_ENABLED=false disables sending."""
+    with patch.dict(
+        os.environ,
+        {"NOTIFICATIONS_ENABLED": "false", "DISCORD_WEBHOOK_URL": "https://discord.com/api/webhooks/1/2"},
+        clear=False,
+    ):
+        manager = NotificationManager({})
+    # Channels may be built from DISCORD_WEBHOOK_URL
+    manager._enabled = False
+    assert manager.enabled is False
+
+
+def test_manager_send_when_disabled_no_op() -> None:
+    """Send does nothing when disabled."""
+    manager = NotificationManager({"enabled": False})
+    manager._channels = []
+    manager.send("trade_opened", {"message": "hello"})
+    # No exception, no side effect (no channels to call)
+
+
+def test_manager_send_trade_event_filtering() -> None:
+    """send_trade respects event_enabled for trade_opened."""
+    with patch.dict(os.environ, {"DISCORD_WEBHOOK_URL": ""}, clear=False):
+        manager = NotificationManager({"events": {"trade_opened": False}})
+    manager._channels = []
+    trade = TradeNotification(
+        symbol="AAPL",
+        side="buy",
+        quantity=10,
+        price=100.0,
+        strategy_name="test",
+        event="trade_opened",
+    )
+    manager.send_trade(trade)
+    # No channels so no HTTP call; event would be skipped anyway
+
+
+def test_manager_get_channel() -> None:
+    """get_channel returns channel by name or None."""
+    url = "https://discord.com/api/webhooks/x/y"
+    with patch.dict(os.environ, {"DISCORD_WEBHOOK_URL": url}, clear=False):
+        manager = NotificationManager({})
+    assert manager.get_channel("discord") is not None
+    assert manager.get_channel("nonexistent") is None

--- a/tests/notifications/test_webhook.py
+++ b/tests/notifications/test_webhook.py
@@ -1,0 +1,28 @@
+"""Tests for generic webhook channel."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from trader.notifications.channels.webhook import WebhookChannel
+
+
+def test_webhook_channel_requires_url() -> None:
+    """WebhookChannel raises if URL is empty."""
+    with pytest.raises(ValueError, match="URL"):
+        WebhookChannel("")
+    with pytest.raises(ValueError, match="URL"):
+        WebhookChannel("   ")
+
+
+def test_webhook_send_posts_json() -> None:
+    """Webhook send POSTs JSON with message and optional event."""
+    with patch.object(requests, "post") as mock_post:
+        mock_post.return_value = MagicMock(status_code=200)
+        ch = WebhookChannel("https://example.com/webhook")
+        ch.send("Test message", event="trade_opened")
+    mock_post.assert_called_once()
+    call_kw = mock_post.call_args[1]
+    assert call_kw["json"]["message"] == "Test message"
+    assert call_kw["json"]["event"] == "trade_opened"

--- a/trader/app/notifications.py
+++ b/trader/app/notifications.py
@@ -1,0 +1,96 @@
+"""App-layer notification services for CLI and MCP."""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from trader.notifications.formatters import TradeNotification
+from trader.notifications.manager import NotificationManager
+
+
+def _config_dir() -> Path:
+    return Path(__file__).parent.parent.parent / "config"
+
+
+def _load_notifications_config() -> dict[str, Any]:
+    """Load optional config/notifications.yaml."""
+    path = _config_dir() / "notifications.yaml"
+    if not path.is_file():
+        return {}
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    if not data or "notifications" not in data:
+        return {}
+    return data["notifications"]
+
+
+def get_notification_manager(config_dir: Path | None = None) -> NotificationManager:
+    """Return a NotificationManager with env + optional YAML config."""
+    if config_dir is None:
+        config_dir = _config_dir()
+    config_path = config_dir / "notifications.yaml"
+    config: dict[str, Any] = {}
+    if config_path.is_file():
+        with open(config_path) as f:
+            data = yaml.safe_load(f)
+        if data and "notifications" in data:
+            config = data["notifications"]
+    return NotificationManager(config)
+
+
+def send_notification(
+    message: str,
+    channel: str | None = None,
+    config_dir: Path | None = None,
+) -> None:
+    """Send a manual notification to configured channel(s).
+
+    Args:
+        message: Text to send.
+        channel: 'discord', 'webhook', or 'all' (default: all enabled).
+        config_dir: Optional config directory for notifications.yaml.
+    """
+    manager = get_notification_manager(config_dir=config_dir)
+    if not manager.enabled:
+        return
+    if channel and channel != "all":
+        ch = manager.get_channel(channel)
+        if ch:
+            ch.send(message)
+    else:
+        manager.send("manual", {"message": message})
+
+
+def send_test_notification(
+    channel: str | None = None,
+    config_dir: Path | None = None,
+) -> bool:
+    """Send a test notification. Returns True if at least one channel succeeded."""
+    manager = get_notification_manager(config_dir=config_dir)
+    if not manager.enabled:
+        return False
+    msg = "AutoTrader test notification — notifications are working."
+    if channel and channel != "all":
+        ch = manager.get_channel(channel)
+        channels = [ch] if ch else []
+    else:
+        channels = [manager.get_channel(n) for n in manager.channel_names]
+        channels = [c for c in channels if c is not None]
+    ok = False
+    for ch in channels:
+        try:
+            ch.send(msg)
+            ok = True
+        except Exception:
+            pass
+    return ok
+
+
+def send_trade_notification(
+    trade: TradeNotification,
+    config_dir: Path | None = None,
+) -> None:
+    """Send a trade open/close notification to all enabled channels."""
+    manager = get_notification_manager(config_dir=config_dir)
+    manager.send_trade(trade)

--- a/trader/audit.py
+++ b/trader/audit.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 from contextvars import ContextVar
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -46,7 +46,7 @@ def log_action(
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / "audit.log"
     record = {
-        "ts": datetime.now(tz=datetime.UTC).isoformat(),
+        "ts": datetime.now(tz=timezone.utc).isoformat(),
         "source": get_audit_source(),
         "action": action,
         "details": details,

--- a/trader/notifications/__init__.py
+++ b/trader/notifications/__init__.py
@@ -1,0 +1,5 @@
+"""Notification delivery for trading events (Discord, webhook)."""
+
+from trader.notifications.manager import NotificationManager
+
+__all__ = ["NotificationManager"]

--- a/trader/notifications/channels/__init__.py
+++ b/trader/notifications/channels/__init__.py
@@ -1,0 +1,7 @@
+"""Notification channel implementations."""
+
+from trader.notifications.channels.base import NotificationChannel
+from trader.notifications.channels.discord import DiscordChannel
+from trader.notifications.channels.webhook import WebhookChannel
+
+__all__ = ["NotificationChannel", "DiscordChannel", "WebhookChannel"]

--- a/trader/notifications/channels/base.py
+++ b/trader/notifications/channels/base.py
@@ -1,0 +1,25 @@
+"""Base notification channel."""
+
+from abc import ABC, abstractmethod
+
+from trader.notifications.formatters import TradeNotification
+
+
+class NotificationChannel(ABC):
+    """Base class for notification channels."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Channel identifier (e.g. 'discord', 'webhook')."""
+        ...
+
+    @abstractmethod
+    def send(self, message: str, **kwargs: object) -> None:
+        """Send a text message through this channel."""
+        ...
+
+    def format_trade(self, trade: TradeNotification) -> str:
+        """Format trade for this channel. Override for channel-specific formatting."""
+        from trader.notifications.formatters import format_trade_plain
+        return format_trade_plain(trade)

--- a/trader/notifications/channels/discord.py
+++ b/trader/notifications/channels/discord.py
@@ -1,0 +1,44 @@
+"""Discord webhook notification channel."""
+
+import logging
+from typing import Any
+
+import requests
+
+from trader.notifications.channels.base import NotificationChannel
+from trader.notifications.formatters import TradeNotification, format_trade_discord
+
+logger = logging.getLogger(__name__)
+
+
+class DiscordChannel(NotificationChannel):
+    """Send notifications via Discord webhook."""
+
+    def __init__(self, webhook_url: str) -> None:
+        if not webhook_url or not webhook_url.strip():
+            raise ValueError("Discord webhook URL is required")
+        self.webhook_url = webhook_url.strip()
+
+    @property
+    def name(self) -> str:
+        return "discord"
+
+    def send(self, message: str, **kwargs: Any) -> None:
+        """Send message via Discord webhook API."""
+        payload: dict[str, Any] = {"content": message[:2000]}
+        if kwargs.get("username"):
+            payload["username"] = str(kwargs["username"])
+        try:
+            resp = requests.post(
+                self.webhook_url,
+                json=payload,
+                timeout=10,
+                headers={"Content-Type": "application/json"},
+            )
+            resp.raise_for_status()
+        except requests.RequestException as e:
+            logger.warning("Discord webhook send failed: %s", e)
+            raise
+
+    def format_trade(self, trade: TradeNotification) -> str:
+        return format_trade_discord(trade)

--- a/trader/notifications/channels/webhook.py
+++ b/trader/notifications/channels/webhook.py
@@ -1,0 +1,44 @@
+"""Generic HTTP webhook notification channel."""
+
+import logging
+from typing import Any
+
+import requests
+
+from trader.notifications.channels.base import NotificationChannel
+from trader.notifications.formatters import TradeNotification, format_trade_plain
+
+logger = logging.getLogger(__name__)
+
+
+class WebhookChannel(NotificationChannel):
+    """Send notifications to a generic HTTP webhook (POST JSON body)."""
+
+    def __init__(self, url: str) -> None:
+        if not url or not url.strip():
+            raise ValueError("Webhook URL is required")
+        self.url = url.strip()
+
+    @property
+    def name(self) -> str:
+        return "webhook"
+
+    def send(self, message: str, **kwargs: Any) -> None:
+        """POST JSON body with 'message' and optional 'event'."""
+        payload: dict[str, Any] = {"message": message}
+        if kwargs.get("event"):
+            payload["event"] = str(kwargs["event"])
+        try:
+            resp = requests.post(
+                self.url,
+                json=payload,
+                timeout=10,
+                headers={"Content-Type": "application/json"},
+            )
+            resp.raise_for_status()
+        except requests.RequestException as e:
+            logger.warning("Webhook send failed: %s", e)
+            raise
+
+    def format_trade(self, trade: TradeNotification) -> str:
+        return format_trade_plain(trade)

--- a/trader/notifications/formatters.py
+++ b/trader/notifications/formatters.py
@@ -1,0 +1,46 @@
+"""Message formatting for notification channels."""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+
+@dataclass
+class TradeNotification:
+    """Payload for trade open/close notifications."""
+
+    symbol: str
+    side: str  # "buy" / "sell"
+    quantity: int | float
+    price: float
+    strategy_name: str
+    timestamp: datetime | None = None
+    event: str = "trade"  # "trade_opened" | "trade_closed"
+
+    def __post_init__(self) -> None:
+        if self.timestamp is None:
+            self.timestamp = datetime.now(timezone.utc)  # noqa: UP017
+
+
+def format_trade_plain(trade: TradeNotification) -> str:
+    """Plain-text trade message (e.g. for generic webhook)."""
+    ts = trade.timestamp.strftime("%Y-%m-%d %H:%M:%S") if trade.timestamp else ""
+    icon = "🟢" if trade.side.lower() == "buy" else "🔴"
+    action = "Opened" if trade.event == "trade_opened" else "Closed"
+    return (
+        f"{icon} **{action} - {trade.symbol}**\n"
+        f"**Side:** {trade.side.upper()}\n"
+        f"**Qty:** {trade.quantity} shares\n"
+        f"**Price:** ${trade.price:.2f}\n"
+        f"**Strategy:** {trade.strategy_name}\n"
+        f"**Time:** {ts}"
+    )
+
+
+def format_trade_discord(trade: TradeNotification) -> str:
+    """Discord-friendly trade message (markdown)."""
+    return format_trade_plain(trade)
+
+
+def format_error_plain(error: Exception) -> str:
+    """Plain-text error message."""
+    return f"⚠️ **Error**\n{type(error).__name__}: {error!s}"

--- a/trader/notifications/manager.py
+++ b/trader/notifications/manager.py
@@ -1,0 +1,134 @@
+"""Notification manager: routes events to configured channels."""
+
+import logging
+import os
+from typing import Any
+
+from trader.notifications.channels.base import NotificationChannel
+from trader.notifications.channels.discord import DiscordChannel
+from trader.notifications.channels.webhook import WebhookChannel
+from trader.notifications.formatters import TradeNotification, format_error_plain
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_EVENTS = {
+    "trade_opened": True,
+    "trade_closed": True,
+    "strategy_started": True,
+    "strategy_stopped": True,
+    "error": True,
+    "daily_summary": True,
+}
+
+
+def _resolve_url(value: str) -> str:
+    """Resolve ${VAR} in config from environment."""
+    if not value:
+        return value
+    s = value.strip()
+    if s.startswith("${") and s.endswith("}"):
+        var = s[2:-1].strip()
+        return os.getenv(var, "")
+    return s
+
+
+def _build_channels(config: dict[str, Any]) -> list[NotificationChannel]:
+    """Build list of enabled channels from config."""
+    channels: list[NotificationChannel] = []
+    # Env override: Discord
+    discord_url = os.getenv("DISCORD_WEBHOOK_URL", "").strip()
+    channels_cfg = config.get("channels") or {}
+    discord_cfg = channels_cfg.get("discord") or {}
+    if discord_cfg.get("enabled", True) and (discord_url or discord_cfg.get("webhook_url")):
+        url = discord_url or _resolve_url(str(discord_cfg.get("webhook_url", "")))
+        if url:
+            try:
+                channels.append(DiscordChannel(url))
+            except ValueError as e:
+                logger.warning("Skip Discord channel: %s", e)
+    # Generic webhook
+    webhook_url = os.getenv("CUSTOM_WEBHOOK_URL", "").strip()
+    webhook_cfg = channels_cfg.get("webhook") or {}
+    if webhook_cfg.get("enabled", False) or webhook_url:
+        url = webhook_url or _resolve_url(str(webhook_cfg.get("url", "")))
+        if url:
+            try:
+                channels.append(WebhookChannel(url))
+            except ValueError as e:
+                logger.warning("Skip webhook channel: %s", e)
+    return channels
+
+
+class NotificationManager:
+    """Manages notification delivery across channels."""
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        """Load notification channels from config (and env).
+
+        Config may contain:
+        - enabled: bool
+        - events: dict of event_name -> bool
+        - channels: dict with discord/webhook settings
+        """
+        self._config = config or {}
+        self._enabled = self._config.get("enabled", True)
+        if os.getenv("NOTIFICATIONS_ENABLED", "").lower() in ("0", "false", "no"):
+            self._enabled = False
+        self._events = {**DEFAULT_EVENTS, **(self._config.get("events") or {})}
+        self._channels = _build_channels(self._config)
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled and len(self._channels) > 0
+
+    @property
+    def channel_names(self) -> list[str]:
+        return [c.name for c in self._channels]
+
+    def get_channel(self, name: str) -> NotificationChannel | None:
+        """Return channel by name, or None."""
+        for c in self._channels:
+            if c.name == name:
+                return c
+        return None
+
+    def _event_enabled(self, event: str) -> bool:
+        return bool(self._events.get(event, True))
+
+    def _send_to_all(self, message: str, event: str | None = None) -> None:
+        if not self.enabled:
+            return
+        for ch in self._channels:
+            try:
+                ch.send(message, event=event)
+            except Exception as e:
+                logger.warning("Notification channel %s failed: %s", ch.name, e)
+
+    def send(self, event: str, data: dict[str, Any]) -> None:
+        """Send notification to all enabled channels.
+
+        Events: trade_opened, trade_closed, strategy_started, strategy_stopped,
+        error, daily_summary.
+        """
+        if not self._enabled or not self._event_enabled(event):
+            return
+        message = data.get("message") or str(data)
+        self._send_to_all(message, event=event)
+
+    def send_trade(self, trade: TradeNotification) -> None:
+        """Format and send trade notification to all channels."""
+        if not self._enabled or not self._event_enabled(trade.event):
+            return
+        for ch in self._channels:
+            try:
+                msg = ch.format_trade(trade)
+                ch.send(msg, event=trade.event)
+            except Exception as e:
+                logger.warning("Notification channel %s failed: %s", ch.name, e)
+
+    def send_error(self, error: Exception) -> None:
+        """Format and send error notification."""
+        if not self._enabled or not self._event_enabled("error"):
+            return
+        message = format_error_plain(error)
+        self._send_to_all(message, event="error")


### PR DESCRIPTION
- Add trader/notifications (NotificationManager, DiscordChannel, WebhookChannel)
- CLI: trader notify test, trader notify send
- Config: DISCORD_WEBHOOK_URL, CUSTOM_WEBHOOK_URL, config/notifications.yaml.example
- App layer: trader/app/notifications.py for engine/MCP use
- 20 tests; fix audit log to use timezone.utc for compatibility